### PR TITLE
Handle Unicode in decompiler output

### DIFF
--- a/src/ghidra2dwarf.py
+++ b/src/ghidra2dwarf.py
@@ -340,7 +340,7 @@ def add_function(cu, func, file_index):
 
 def write_source():
     with open(decompiled_c_path, "wb") as src:
-        src.write("\n".join(decomp_lines))
+        src.write("\n".join(decomp_lines).encode("utf8"))
 
 
 def add_type(cu, t):


### PR DESCRIPTION
The decompiler output can legitimately contain Unicode (e.g. Unicode strings). Currently, the script will crash with an error like this:

```
Traceback (most recent call last):
  File "ghidra2dwarf.py", line 512, in <module>
    write_source()
  File "ghidra2dwarf.py", line 343, in write_source
    src.write("\n".join(decomp_lines))
UnicodeEncodeError: 'ascii' codec can't encode character u'\uefbe' in position 14630: ordinal not in range(128)
```

This fix makes the output UTF-8, which solves this issue for all valid Unicode characters.