### PR TITLE
Move output to /tmp/

### DIFF
--- a/src/ghidra2dwarf.py
+++ b/src/ghidra2dwarf.py
@@ -72,8 +72,8 @@ while not os.path.isfile(exe_path):
     curr.executablePath = exe_path
     print "Changed binary path to %s." % exe_path
 
-out_path = exe_path + "_dbg"
-decompiled_c_path = exe_path + "_dbg.c"
+out_path = "/tmp/ghidra2elf"
+decompiled_c_path = out_path + ".c"
 decomp_lines = []
 
 ERR_IS_NOT_OK = lambda e: e != DW_DLV_OK


### PR DESCRIPTION
This is merely a feature proposal.

Ideally the user could control the output path.

In my case, I mount disk images and analyze/decompile files in those.
These disks are typically read-only, so writing the file to the `exe_path` will fail.

My workaround is to move it to `/tmp/` which works fine on Linux and macOS.